### PR TITLE
Fixed a minor spelling mistake with a method name in the README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,14 +186,14 @@ The default Jackson property detection rules will find:
 But if this does not work, you can change visibility levels by using annotation `@JsonAutoDetect`.
 If you wanted, for example, to auto-detect ALL fields (similar to how packages like GSON work), you could do:
 
-    @JsonAutoDetect(fieldVisiblity=JsonAutoDetect.Visibility.ANY)
+    @JsonAutoDetect(fieldVisibility=JsonAutoDetect.Visibility.ANY)
     public class POJOWithFields {
       private int value;
     }
 
 or, to disable auto-detection of fields altogether:
 
-    @JsonAutoDetect(fieldVisiblity=JsonAutoDetect.Visibility.NONE)
+    @JsonAutoDetect(fieldVisibility=JsonAutoDetect.Visibility.NONE)
     public class POJOWithNoFields {
       // will NOT be included, unless there is access 'getValue()'
       public int value;


### PR DESCRIPTION
Hey I found a spelling mistake in the instructions that caused me some confusion and I hope you are able to merge my fix so others don't have to go through the same pain :)
