### PR TITLE
Human readable description support

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/JsonPropertyDescription.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonPropertyDescription.java
@@ -1,0 +1,25 @@
+package com.fasterxml.jackson.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotaion used to define a human readable description for a logical
+ * property.
+ * Currently used to populate the description field in generated JSON
+ * Schemas.
+ */
+@Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@JacksonAnnotation
+public @interface JsonPropertyDescription
+{
+    /**
+     * Defines a human readable description of the logical property.
+     * Currently used to populate the description field in generated JSON
+     * Schemas.
+     */
+    String value() default "";
+}


### PR DESCRIPTION
See: https://github.com/FasterXML/jackson-module-jsonSchema/issues/12

JSON Schema (v3 and v4) allows a human readable description to be associated with each field: http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.22

It would be good to have an annotation for defining a description for each property, which the JSON Schema Jackson module can respect.
