### PR TITLE
Add a note on README regarding renaming properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ or download jars from Maven repository (or via quick links on [Wiki](../../wiki)
 
 ## Usage, simple
 
-Let's start with simple use cases: renaming or ignoring properties, and modifying types that are used.
+Let's start with simple use cases: renaming or ignoring properties during object serialization, and modifying types that are used.
 
 Note: while examples only show field properties, same annotations would work with method (getter/setter) properties.
 


### PR DESCRIPTION
Add a note on README to make it clear that annotations for renaming properties such as @JsonProperty applies during object serialization (marshalling phase) and not during unmarshalling where both JSON property and field name must match.