### PR TITLE
Add the createItem method to ObjectIdResolver

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/ObjectIdResolver.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/ObjectIdResolver.java
@@ -55,4 +55,16 @@ public interface ObjectIdResolver {
      * @return True if this instance can be used as-is; false if not
      */
     boolean canUseFor(ObjectIdResolver resolverType);
+
+    /**
+     * Method called when a reference was not resolved at all and the deserializer
+     * is about to throw an UnresolvedForwardReference exception.
+     *
+     * This is the last chance to resolve all missing pieces. If you want to report
+     * an UnresolvedForwardReference exception, simply return null.
+     *
+     * @param id The Object Identifier
+     * @return The POJO, or null if unable to resolve.
+     */
+    Object createItem(IdKey id);
 }

--- a/src/main/java/com/fasterxml/jackson/annotation/SimpleObjectIdResolver.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/SimpleObjectIdResolver.java
@@ -43,4 +43,10 @@ public class SimpleObjectIdResolver implements ObjectIdResolver {
         //    (and worse, cause unnecessary memory retention)
         return new SimpleObjectIdResolver();
     }
+
+    @Override
+    public Object createItem(IdKey id) {
+        // The default resolver reports unresolved forward references
+        return null;
+    }
 }


### PR DESCRIPTION
This method allows the deserializer to attempt resolving of the
missing forward reference by creating and binding a new object.

It should be applied together with my other pull request for the databind subproject and those two together should solve databind's issue #670. 