### PR TITLE
JPMS Strictly Named Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ To use annotations, you need to use Maven dependency:
 
 or download jars from Maven repository (or via quick links on [Wiki](../../wiki))
 
+
+# JPMS Configuration
+This module is strictly defined and the module-info.java is attached with the [moditect](https://github.com/moditect/moditect) plugin
+
+This allows for transitive dependencies, and will not place this library in the Automatic Named Modules.
+
+This modules name is ```com.fasterxml.jackson.annotation```
+
+-----
+
 ## Usage, simple
 
 Let's start with simple use cases: renaming or ignoring properties, and modifying types that are used.

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion> 
+    <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.fasterxml.jackson</groupId>
     <!-- this is one of few Jackson modules that depends on parent and NOT jackson-bom -->
     <artifactId>jackson-parent</artifactId>
-    <version>2.9.1</version>
+      <version>2.9.1.1</version>
   </parent>
 
   <groupId>com.fasterxml.jackson.core</groupId>
@@ -26,9 +26,20 @@
   </scm>
 
   <properties>
-    <!-- 02-Oct-2015, tatu: Retain Java6/JDK1.6 compatibility for annotations for Jackson 2.x -->
-    <javac.src.version>1.6</javac.src.version>
-    <javac.target.version>1.6</javac.target.version>
+      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
+              and new language features (diamond pattern) may be used.
+              JDK classes are still loaded dynamically since there isn't much downside
+              (small number of types); this allows use on JDK 6 platforms still (including
+              Android)
+           -->
+      <!-- TODO Remove JDK 11 Settings -->
+      <javac.src.version>1.11</javac.src.version>
+      <javac.target.version>1.11</javac.target.version>
+
+      <jdk.version>1.11</jdk.version>
+      <maven.compiler.source>1.11</maven.compiler.source>
+      <maven.compiler.target>1.11</maven.compiler.target>
+      <maven.compiler.release>11</maven.compiler.release>
     <!-- 02-Jun-2016, tatu: Looks like newer versions (3.0+) of bundle plugin require Java 7 (directly
             or via transitive deps), so need to downgrade
       -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.fasterxml.jackson</groupId>
     <!-- this is one of few Jackson modules that depends on parent and NOT jackson-bom -->
     <artifactId>jackson-parent</artifactId>
-      <version>2.9.1.1</version>
+      <version>2.9.1.2</version>
   </parent>
 
   <groupId>com.fasterxml.jackson.core</groupId>
@@ -26,25 +26,10 @@
   </scm>
 
   <properties>
-      <!-- With Jackson 2.9 we will require JDK 7 (except for annotations/streaming),
-              and new language features (diamond pattern) may be used.
-              JDK classes are still loaded dynamically since there isn't much downside
-              (small number of types); this allows use on JDK 6 platforms still (including
-              Android)
-           -->
-      <!-- TODO Remove JDK 11 Settings -->
-      <javac.src.version>1.11</javac.src.version>
-      <javac.target.version>1.11</javac.target.version>
-
-      <jdk.version>1.11</jdk.version>
-      <maven.compiler.source>1.11</maven.compiler.source>
-      <maven.compiler.target>1.11</maven.compiler.target>
-      <maven.compiler.release>11</maven.compiler.release>
     <!-- 02-Jun-2016, tatu: Looks like newer versions (3.0+) of bundle plugin require Java 7 (directly
             or via transitive deps), so need to downgrade
       -->
     <version.plugin.bundle>2.5.3</version.plugin.bundle>
-
     <osgi.export>com.fasterxml.jackson.annotation.*;version=${project.version}</osgi.export>
   </properties>
 
@@ -71,6 +56,42 @@
           </instructions>
 	</configuration>
       </plugin>
+	  
+		 <plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-compiler-plugin</artifactId>
+			<version>3.8.0</version>
+			<dependencies>
+				<dependency>
+					<groupId>org.ow2.asm</groupId>
+					<artifactId>asm</artifactId>
+					<version>7.0</version>
+				</dependency>
+			</dependencies>
+		</plugin>
+
+        <plugin>
+            <groupId>org.moditect</groupId>
+            <artifactId>moditect-maven-plugin</artifactId>
+            <version>1.0.0.Beta1</version>
+            <executions>
+                <execution>
+                    <id>add-module-infos</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>add-module-info</goal>
+                    </goals>
+                    <configuration>
+                        <overwriteExistingFiles>true</overwriteExistingFiles>
+                        <module>
+                            <moduleInfoFile>
+                                src/moditect/module-info.java
+                            </moduleInfoFile>
+                        </module>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,15 @@
   <properties>
     <!-- 02-Jun-2016, tatu: Looks like newer versions (3.0+) of bundle plugin require Java 7 (directly
             or via transitive deps), so need to downgrade
+
+        Jackson 2.7 and above Java 7 (with exception of `jackson-core`/`jackson-annotations` still Java 6),
       -->
     <version.plugin.bundle>2.5.3</version.plugin.bundle>
+      <javac.src.version>1.6</javac.src.version>
+      <javac.target.version>1.6</javac.target.version>
+
+      <maven.compiler.source>1.6</maven.compiler.source>
+      <maven.compiler.target>1.6</maven.compiler.target>
     <osgi.export>com.fasterxml.jackson.annotation.*;version=${project.version}</osgi.export>
   </properties>
 
@@ -56,24 +63,10 @@
           </instructions>
 	</configuration>
       </plugin>
-	  
-		 <plugin>
-			<groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-compiler-plugin</artifactId>
-			<version>3.8.0</version>
-			<dependencies>
-				<dependency>
-					<groupId>org.ow2.asm</groupId>
-					<artifactId>asm</artifactId>
-					<version>7.0</version>
-				</dependency>
-			</dependencies>
-		</plugin>
 
         <plugin>
             <groupId>org.moditect</groupId>
             <artifactId>moditect-maven-plugin</artifactId>
-            <version>1.0.0.Beta1</version>
             <executions>
                 <execution>
                     <id>add-module-infos</id>

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,0 +1,4 @@
+module com.fasterxml.jackson.annotation {
+	exports com.fasterxml.jackson.annotation;
+
+}

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,4 +1,3 @@
 module com.fasterxml.jackson.annotation {
 	exports com.fasterxml.jackson.annotation;
-
 }


### PR DESCRIPTION
* JAXB Bump to 2.3.0
* Guice Minimum set to 4.2.2 for JPMS
* JSON Setter - couldn't find merge annotation method on branch 2.9
* JPMS Strictly Named Modules with Hard Exports ONLY

JPMS Considerations
===================
For Private/Protected Field Scanning, The required package should open to com.fasterxml.jackson.databind.
This is how it currently works with automatic module naming, but it is now strictly enforced