### PR TITLE
Make JsonSubTypes.Type a repeatable annotation

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/JsonSubTypes.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonSubTypes.java
@@ -1,6 +1,7 @@
 package com.fasterxml.jackson.annotation;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -34,6 +35,7 @@ public @interface JsonSubTypes {
      * name will be constructed by type id mechanism.
      * Default name is usually based on class name.
      */
+    @Repeatable(JsonSubTypes.class)
     public @interface Type {
         /**
          * Class of the subtype


### PR DESCRIPTION
In Java8, having a wrapper annotation is not needed anymore if you make the wrapped annotation `@Repeatable` (see [this page](https://docs.oracle.com/javase/tutorial/java/annotations/repeating.html)). I'm just worry there was a reason behind this change not being done so please comment if there is.