### PR TITLE
Add basic Java 9+ module info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <!-- 04-Mar-2019, tatu: Retain Java6/JDK1.6 compatibility for annotations for Jackson 2.x,
-            but use Moditect to get JDK9+ module info support; need newer bundle plugin as well
+             but use Moditect to get JDK9+ module info support; need newer bundle plugin as well
       -->
     <javac.src.version>1.6</javac.src.version>
     <javac.target.version>1.6</javac.target.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,16 @@
   </scm>
 
   <properties>
-    <!-- 02-Oct-2015, tatu: Retain Java6/JDK1.6 compatibility for annotations for Jackson 2.x -->
+    <!-- 04-Mar-2019, tatu: Retain Java6/JDK1.6 compatibility for annotations for Jackson 2.x,
+            but use Moditect to get JDK9+ module info support; need newer bundle plugin as well
+      -->
     <javac.src.version>1.6</javac.src.version>
     <javac.target.version>1.6</javac.target.version>
-    <!-- 02-Jun-2016, tatu: Looks like newer versions (3.0+) of bundle plugin require Java 7 (directly
-            or via transitive deps), so need to downgrade
-      -->
-    <version.plugin.bundle>2.5.3</version.plugin.bundle>
+
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+
+    <version.plugin.bundle>3.2.0</version.plugin.bundle>
 
     <osgi.export>com.fasterxml.jackson.annotation.*;version=${project.version}</osgi.export>
   </properties>
@@ -58,7 +61,26 @@
           <instructions combine.children="merge">
             <Automatic-Module-Name>com.fasterxml.jackson.annotation</Automatic-Module-Name>
           </instructions>
-	</configuration>
+	   </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+              <overwriteExistingFiles>true</overwriteExistingFiles>
+              <module>
+                <moduleInfoFile>src/moditect/module-info.java</moduleInfoFile>
+              </module>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/moditect/module-info.java
+++ b/src/moditect/module-info.java
@@ -1,0 +1,3 @@
+module com.fasterxml.jackson.annotation {
+    exports com.fasterxml.jackson.annotation;
+}


### PR DESCRIPTION
As per ealier PR #145. Seems to load ok with JDK 7 and JDK 8 too but need to verify if need to move under `version/9` for tooling or something.