### PR TITLE
Ability to use JsonAnyGetter on fields

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/JsonAnyGetter.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonAnyGetter.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Target;
  * with this annotation; if multiple methods are annotated, an exception
  * may be thrown.
  */
-@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @JacksonAnnotation
 public @interface JsonAnyGetter


### PR DESCRIPTION
Adds the necessary target-type to use @JsonAnyGetter on fields. This is required to solve:
https://github.com/FasterXML/jackson-databind/issues/1458