### PR TITLE
fix a flaky test

### DIFF
--- a/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
@@ -39,9 +39,6 @@ public class JsonIncludePropertiesTest extends TestBase
         String tmp = v.toString();
         boolean test1 = tmp.equals("JsonIncludeProperties.Value(included=[foo, bar])");
         boolean test2 = tmp.equals("JsonIncludeProperties.Value(included=[bar, foo])");
-        System.out.println(tmp);
-        System.out.println(test1);
-        System.out.println(test2);
         assertTrue(test1 || test2);
         assertEquals(v, JsonIncludeProperties.Value.from(Bogus.class.getAnnotation(JsonIncludeProperties.class)));
     }

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static org.junit.Assert.assertTrue;
+
 /**
  * Tests to verify that it is possibly to merge {@link JsonIncludeProperties.Value}
  * instances for overrides
@@ -34,7 +36,7 @@ public class JsonIncludePropertiesTest extends TestBase
         Set<String> included = v.getIncluded();
         assertEquals(2, v.getIncluded().size());
         assertEquals(_set("foo", "bar"), included);
-        assertEquals("JsonIncludeProperties.Value(included=[bar, foo])", v.toString());
+        assertTrue(v.toString().equals("JsonIncludeProperties.Value(included=[bar, foo])") || v.toString().equals("JsonIncludeProperties.Value(included=[foo, bar])"));
         assertEquals(v, JsonIncludeProperties.Value.from(Bogus.class.getAnnotation(JsonIncludeProperties.class)));
     }
 

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
@@ -36,7 +36,13 @@ public class JsonIncludePropertiesTest extends TestBase
         Set<String> included = v.getIncluded();
         assertEquals(2, v.getIncluded().size());
         assertEquals(_set("foo", "bar"), included);
-        assertTrue(v.toString().equals("JsonIncludeProperties.Value(included=[bar, foo])") || v.toString().equals("JsonIncludeProperties.Value(included=[foo, bar])"));
+        String tmp = v.toString();
+        boolean test1 = tmp.equals("JsonIncludeProperties.Value(included=[foo, bar])");
+        boolean test2 = tmp.equals("JsonIncludeProperties.Value(included=[bar, foo])");
+        System.out.println(tmp);
+        System.out.println(test1);
+        System.out.println(test2);
+        assertTrue(test1 || test2);
         assertEquals(v, JsonIncludeProperties.Value.from(Bogus.class.getAnnotation(JsonIncludeProperties.class)));
     }
 


### PR DESCRIPTION
In the test `testFromAnnotation`, included was supposed to be a `set`. Therefore, the order of 'foo' and 'bar' is not fixed.