### PR TITLE
Add enum features into JsonFormat.Feature

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java
@@ -261,7 +261,21 @@ public @interface JsonFormat
          */
         ACCEPT_CASE_INSENSITIVE_PROPERTIES,
 
+        /**
+         * Override for <code>DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL</code>,
+         * which allows unknown Enum values to be parsed as null values.
+         *
+         * @since 2.15
+         */
         READ_UNKNOWN_ENUM_VALUES_AS_NULL,
+
+        /**
+         * Override for <code>DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE</code>,
+         * which allows unknown Enum values to be ignored and a predefined value specified through
+         * {@link com.fasterxml.jackson.annotation.JsonEnumDefaultValue @JsonEnumDefaultValue} annotation.
+         *
+         * @since 2.15
+         */
         READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE,
 
         /**

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java
@@ -261,6 +261,9 @@ public @interface JsonFormat
          */
         ACCEPT_CASE_INSENSITIVE_PROPERTIES,
 
+        READ_UNKNOWN_ENUM_VALUES_AS_NULL,
+        READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE,
+
         /**
          * Override for <code>MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES</code>,
          * which allows case-sensitive matching of (some) property values, such


### PR DESCRIPTION
Add enum features into JsonFormat.Feature

- READ_UNKNOWN_ENUM_VALUES_AS_NULL
- READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE 

Related PR: https://github.com/FasterXML/jackson-databind/pull/3731
Issue : https://github.com/FasterXML/jackson-databind/issues/3637

Note: Java Doc Comments are pending.