### PR TITLE
Doc: improve JavaDoc of JsonAlias about ordering of alias and JSON keys

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/JsonAlias.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonAlias.java
@@ -18,6 +18,30 @@ import java.lang.annotation.Target;
  *  public String name;
  *}
  *</pre>
+ * </p>
+ * <p>
+ * NOTE: When there is more than one <b>alias-to-key match</b>, "Last one wins"
+ * rule is applied to the key of deserialization target object. But the same
+ * rule does NOT apply to the order of {@link JsonAlias#value()} field.
+ * </p>
+ * <p>
+ * For example,
+ * <pre>
+ * public class Person {
+ *    &#64;JsonAlias({ "name", "fullName" })
+ *    public String description;
+ * }
+ * </pre>
+ * below JSON object will be deserialized with <code>description</code> field value of "Jackson".
+ * <pre>
+ *  { "fullName": "Faster Jackson", "name": "Jackson"}
+ * </pre>
+ * And below JSON object will be deserialized with <code>description</code>
+ * field value of "Faster Jackson".
+ * <pre>
+ *  { "name": "Jackson", "fullName": "Faster Jackson"}
+ * </pre>
+ * </p>
  *
  * @since 2.9
  */

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonAlias.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonAlias.java
@@ -18,31 +18,22 @@ import java.lang.annotation.Target;
  *  public String name;
  *}
  *</pre>
- * </p>
  * <p>
- * NOTE: When there is more than one <b>alias-to-key match</b>, "Last one wins"
- * rule is applied to the key of deserialization target object. But the same
- * rule does NOT apply to the order of {@link JsonAlias#value()} field.
- * </p>
- * <p>
- * For example,
+ * NOTE: Order of alias declaration has no effect. All properties are assigned
+ * in the order they come from incoming JSON document. If same property is
+ * assigned more than once with different value, later will remain.
+ * For example, deserializing
  * <pre>
  * public class Person {
  *    &#64;JsonAlias({ "name", "fullName" })
- *    public String description;
+ *    public String name;
  * }
  * </pre>
- * below JSON object will be deserialized with <code>description</code> field value of "Jackson".
+ * from
  * <pre>
- *  { "fullName": "Faster Jackson", "name": "Jackson"}
+ * { "fullName": "Faster Jackson", "name": "Jackson" }
  * </pre>
- * And below JSON object will be deserialized with <code>description</code>
- * field value of "Faster Jackson".
- * <pre>
- *  { "name": "Jackson", "fullName": "Faster Jackson"}
- * </pre>
- * </p>
- *
+ * will have value "Jackson".
  * @since 2.9
  */
 @Target({ElementType.ANNOTATION_TYPE, // for combo-annotations


### PR DESCRIPTION
## Description

- discussed in FasterXML/jackson-databind#3788
- improves JavaDoc of JsonAlias about ordering of alias and JSON keys
- PS: let me know if I am missing anything, thanks!

## Output JavaDoc

![image](https://user-images.githubusercontent.com/61615301/220097954-3c7059f2-f553-4428-9efa-2c94dbb62e4b.png)
