### PR TITLE
Improve JavaDoc on serialization side of `JsonTypeInfo.Id.DEDUCTION` 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
     <!-- 04-Mar-2019, tatu: Retain Java6/JDK1.6 compatibility for annotations for Jackson 2.x,
              but use Moditect to get JDK9+ module info support; need newer bundle plugin as well
       -->
+    <javac.src.version>1.6</javac.src.version>
+    <javac.target.version>1.6</javac.target.version>
+
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+
     <osgi.export>com.fasterxml.jackson.annotation.*;version=${project.version}</osgi.export>
 
     <!-- for Reproducible Builds -->

--- a/pom.xml
+++ b/pom.xml
@@ -41,12 +41,6 @@
     <!-- 04-Mar-2019, tatu: Retain Java6/JDK1.6 compatibility for annotations for Jackson 2.x,
              but use Moditect to get JDK9+ module info support; need newer bundle plugin as well
       -->
-    <javac.src.version>1.6</javac.src.version>
-    <javac.target.version>1.6</javac.target.version>
-
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
-
     <osgi.export>com.fasterxml.jackson.annotation.*;version=${project.version}</osgi.export>
 
     <!-- for Reproducible Builds -->

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
@@ -126,6 +126,8 @@ public @interface JsonTypeInfo
          * thrown if not enough unique information is present to select a single subtype.
          * <br>If deduction is being used annotation properties {@code visible},
          * {@code property} and {@code include} are ignored.
+         * <p>
+         * On serialization, no type ID is written, and only regular properties are included.
          *
          * @since 2.12.0.
          */


### PR DESCRIPTION
Sprung from explanantion of `JsonTypeInfo.Id.DEDUCTION` provided by @cowtowncoder  in [[jackson-user] google group](https://groups.google.com/g/jackson-user/c/9_zJ2cgA20Q/m/hxPV_1n0AwAJ).