### PR TITLE
Add `requireTypeIdForSubtypes` property for `JsonTypeInfo.Value` in Jackson 3.0

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
@@ -212,8 +212,11 @@ public @interface JsonTypeInfo
          * whereas with {@link JsonTypeId}, output of regular property is suppressed.
          * This mostly matters with respect to output order; this choice is the only
          * way to ensure specific placement of type id during serialization.
+<<<<<<< HEAD
+=======
          *
          * @since 2.3 but databind <b>only since 2.5</b>.
+>>>>>>> 2.16
          */
         EXISTING_PROPERTY
         ;

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
@@ -344,7 +344,6 @@ public @interface JsonTypeInfo
         protected final Class<?> _defaultImpl;
         protected final boolean _idVisible;
         protected final Boolean _requireTypeIdForSubtypes;
-        
 
         /*
         /**********************************************************************

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
@@ -216,7 +216,7 @@ public @interface JsonTypeInfo
 =======
          *
          * @since 2.3 but databind <b>only since 2.5</b>.
->>>>>>> 2.16
+>>>>>>> 2.16 
          */
         EXISTING_PROPERTY
         ;

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
@@ -212,11 +212,8 @@ public @interface JsonTypeInfo
          * whereas with {@link JsonTypeId}, output of regular property is suppressed.
          * This mostly matters with respect to output order; this choice is the only
          * way to ensure specific placement of type id during serialization.
-<<<<<<< HEAD
-=======
          *
          * @since 2.3 but databind <b>only since 2.5</b>.
->>>>>>> 2.16
          */
         EXISTING_PROPERTY
         ;

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
@@ -335,7 +335,7 @@ public @interface JsonTypeInfo
 
         // should not really be needed usually but make sure defalts to `NONE`; other
         // values of less interest
-        protected final static Value EMPTY = new Value(Id.NONE, As.PROPERTY, null, null, false);
+        protected final static Value EMPTY = new Value(Id.NONE, As.PROPERTY, null, null, false, null);
 
         protected final Id _idType;
         protected final As _inclusionType;
@@ -343,6 +343,8 @@ public @interface JsonTypeInfo
 
         protected final Class<?> _defaultImpl;
         protected final boolean _idVisible;
+        protected final Boolean _requireTypeIdForSubtypes;
+        
 
         /*
         /**********************************************************************
@@ -351,17 +353,18 @@ public @interface JsonTypeInfo
          */
 
         protected Value(Id idType, As inclusionType,
-                String propertyName, Class<?> defaultImpl, boolean idVisible)
+                String propertyName, Class<?> defaultImpl, boolean idVisible, Boolean requireTypeIdForSubtypes)
         {
             _defaultImpl = defaultImpl;
             _idType = idType;
             _inclusionType = inclusionType;
             _propertyName = propertyName;
             _idVisible = idVisible;
+            _requireTypeIdForSubtypes = requireTypeIdForSubtypes;
         }
 
         public static Value construct(Id idType, As inclusionType,
-                String propertyName, Class<?> defaultImpl, boolean idVisible)
+                String propertyName, Class<?> defaultImpl, boolean idVisible, Boolean requireTypeIdForSubtypes)
         {
             // couple of overrides we need to apply here. First: if no propertyName specified,
             // use Id-specific property name
@@ -377,7 +380,7 @@ public @interface JsonTypeInfo
             if ((defaultImpl == null) || defaultImpl.isAnnotation()) {
                 defaultImpl = null;
             }
-            return new Value(idType, inclusionType, propertyName, defaultImpl, idVisible);
+            return new Value(idType, inclusionType, propertyName, defaultImpl, idVisible, requireTypeIdForSubtypes);
         }
 
         public static Value from(JsonTypeInfo src) {
@@ -385,7 +388,7 @@ public @interface JsonTypeInfo
                 return null;
             }
             return construct(src.use(), src.include(),
-                    src.property(), src.defaultImpl(), src.visible());
+                    src.property(), src.defaultImpl(), src.visible(), src.requireTypeIdForSubtypes().asBoolean());
         }
 
         /*
@@ -396,27 +399,32 @@ public @interface JsonTypeInfo
 
         public Value withDefaultImpl(Class<?> impl) {
             return (impl == _defaultImpl) ? this :
-                new Value(_idType, _inclusionType, _propertyName, impl, _idVisible);
+                new Value(_idType, _inclusionType, _propertyName, impl, _idVisible, _requireTypeIdForSubtypes);
         }
 
         public Value withIdType(Id idType) {
             return (idType == _idType) ? this :
-                new Value(idType, _inclusionType, _propertyName, _defaultImpl, _idVisible);
+                new Value(idType, _inclusionType, _propertyName, _defaultImpl, _idVisible, _requireTypeIdForSubtypes);
         }
 
         public Value withInclusionType(As inclusionType) {
             return (inclusionType == _inclusionType) ? this :
-                new Value(_idType, inclusionType, _propertyName, _defaultImpl, _idVisible);
+                new Value(_idType, inclusionType, _propertyName, _defaultImpl, _idVisible, _requireTypeIdForSubtypes);
         }
 
         public Value withPropertyName(String propName) {
             return (propName == _propertyName) ? this :
-                new Value(_idType, _inclusionType, propName, _defaultImpl, _idVisible);
+                new Value(_idType, _inclusionType, propName, _defaultImpl, _idVisible, _requireTypeIdForSubtypes);
         }
 
         public Value withIdVisible(boolean visible) {
             return (visible == _idVisible) ? this :
-                new Value(_idType, _inclusionType, _propertyName, _defaultImpl, visible);
+                new Value(_idType, _inclusionType, _propertyName, _defaultImpl, visible, _requireTypeIdForSubtypes);
+        }
+        
+        public Value withRequireTypeIdForSubtypes(Boolean requireTypeIdForSubtypes) {
+            return (_requireTypeIdForSubtypes == requireTypeIdForSubtypes) ? this :
+                new Value(_idType, _inclusionType, _propertyName, _defaultImpl, _idVisible, requireTypeIdForSubtypes);
         }
 
         /*
@@ -435,6 +443,7 @@ public @interface JsonTypeInfo
         public As getInclusionType() { return _inclusionType; }
         public String getPropertyName() { return _propertyName; }
         public boolean getIdVisible() { return _idVisible; }
+        public Boolean getRequireTypeIdForSubtypes() { return _requireTypeIdForSubtypes; }
 
         /**
          * Static helper method for simple(r) checking of whether there's a Value instance
@@ -453,15 +462,16 @@ public @interface JsonTypeInfo
 
         @Override
         public String toString() {
-            return String.format("JsonTypeInfo.Value(idType=%s,includeAs=%s,propertyName=%s,defaultImpl=%s,idVisible=%s)",
+            return String.format("JsonTypeInfo.Value(idType=%s,includeAs=%s,propertyName=%s,defaultImpl=%s,idVisible=%s" 
+                            + ",requireTypeIdForSubtypes=%s)",
                     _idType, _inclusionType, _propertyName,
                     ((_defaultImpl == null) ? "NULL" : _defaultImpl.getName()),
-                    _idVisible);
+                    _idVisible, _requireTypeIdForSubtypes);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(_idType, _inclusionType, _propertyName, _defaultImpl)
+            return Objects.hash(_idType, _inclusionType, _propertyName, _defaultImpl, _requireTypeIdForSubtypes)
                 + (_idVisible ? 11 : -17);
         }
 
@@ -480,6 +490,7 @@ public @interface JsonTypeInfo
                     && (a._defaultImpl == b._defaultImpl)
                     && (a._idVisible == b._idVisible)
                     && Objects.equals(a._propertyName, b._propertyName)
+                    && Objects.equals(a._requireTypeIdForSubtypes, b._requireTypeIdForSubtypes)
             ;
         }
     }

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonTypeInfoTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonTypeInfoTest.java
@@ -5,14 +5,19 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 public class JsonTypeInfoTest extends TestBase
 {
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, visible=true,
-            defaultImpl = JsonTypeInfo.class)
+            defaultImpl = JsonTypeInfo.class, requireTypeIdForSubtypes = OptBoolean.TRUE)
     private final static class Anno1 { }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.EXTERNAL_PROPERTY,
             property = "ext",
-            defaultImpl = Void.class)
+            defaultImpl = Void.class, requireTypeIdForSubtypes = OptBoolean.FALSE)
     private final static class Anno2 { }
 
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = As.EXTERNAL_PROPERTY,
+            property = "ext",
+            defaultImpl = Void.class)
+    private final static class Anno3 { }
+    
     public void testEmpty() {
         // 07-Mar-2017, tatu: Important to distinguish "none" from 'empty' value...
         assertNull(JsonTypeInfo.Value.from(null));
@@ -28,6 +33,7 @@ public class JsonTypeInfoTest extends TestBase
         assertEquals("@class", v1.getPropertyName());
         assertTrue(v1.getIdVisible());
         assertNull(v1.getDefaultImpl());
+        assertTrue(v1.getRequireTypeIdForSubtypes());
 
         JsonTypeInfo.Value v2 = JsonTypeInfo.Value.from(Anno2.class.getAnnotation(JsonTypeInfo.class));
         assertEquals(JsonTypeInfo.Id.NAME, v2.getIdType());
@@ -35,6 +41,7 @@ public class JsonTypeInfoTest extends TestBase
         assertEquals("ext", v2.getPropertyName());
         assertFalse(v2.getIdVisible());
         assertEquals(Void.class, v2.getDefaultImpl());
+        assertFalse(v2.getRequireTypeIdForSubtypes());
 
         assertTrue(v1.equals(v1));
         assertTrue(v2.equals(v2));
@@ -42,8 +49,8 @@ public class JsonTypeInfoTest extends TestBase
         assertFalse(v1.equals(v2));
         assertFalse(v2.equals(v1));
 
-        assertEquals("JsonTypeInfo.Value(idType=CLASS,includeAs=PROPERTY,propertyName=@class,defaultImpl=NULL,idVisible=true)", v1.toString());
-        assertEquals("JsonTypeInfo.Value(idType=NAME,includeAs=EXTERNAL_PROPERTY,propertyName=ext,defaultImpl=java.lang.Void,idVisible=false)", v2.toString());
+        assertEquals("JsonTypeInfo.Value(idType=CLASS,includeAs=PROPERTY,propertyName=@class,defaultImpl=NULL,idVisible=true,requireTypeIdForSubtypes=true)", v1.toString());
+        assertEquals("JsonTypeInfo.Value(idType=NAME,includeAs=EXTERNAL_PROPERTY,propertyName=ext,defaultImpl=java.lang.Void,idVisible=false,requireTypeIdForSubtypes=false)", v2.toString());
     }
 
     public void testMutators() throws Exception
@@ -68,5 +75,32 @@ public class JsonTypeInfoTest extends TestBase
         assertFalse(v.withIdVisible(false).getIdVisible());
 
         assertEquals("foobar", v.withPropertyName("foobar").getPropertyName());
+    }
+
+    public void testWithRequireTypeIdForSubtypes() {
+        // Create an empty JsonTypeInfo.Value object
+        JsonTypeInfo.Value empty = JsonTypeInfo.Value.EMPTY;
+        assertNull(empty.getRequireTypeIdForSubtypes());
+
+        // Set requireTypeIdForSubtypes to OptBoolean.TRUE
+        JsonTypeInfo.Value requireTypeIdTrue = empty.withRequireTypeIdForSubtypes(Boolean.TRUE);
+        assertEquals(Boolean.TRUE, requireTypeIdTrue.getRequireTypeIdForSubtypes());
+
+        // Set requireTypeIdForSubtypes to OptBoolean.FALSE
+        JsonTypeInfo.Value requireTypeIdFalse = empty.withRequireTypeIdForSubtypes(Boolean.FALSE);
+        assertEquals(Boolean.FALSE, requireTypeIdFalse.getRequireTypeIdForSubtypes());
+
+        // Set requireTypeIdForSubtypes to OptBoolean.DEFAULT
+        JsonTypeInfo.Value requireTypeIdDefault = empty.withRequireTypeIdForSubtypes(null);
+        assertNull(requireTypeIdDefault.getRequireTypeIdForSubtypes());
+    }
+    
+    public void testDefaultValueForRequireTypeIdForSubtypes() {
+        JsonTypeInfo.Value v3 = JsonTypeInfo.Value.from(Anno3.class.getAnnotation(JsonTypeInfo.class));
+        assertNull(v3.getRequireTypeIdForSubtypes());
+        
+        // toString
+        assertEquals("JsonTypeInfo.Value(idType=NAME,includeAs=EXTERNAL_PROPERTY,propertyName=ext," 
+                + "defaultImpl=java.lang.Void,idVisible=false,requireTypeIdForSubtypes=null)", v3.toString());
     }
 }

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonTypeInfoTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonTypeInfoTest.java
@@ -78,28 +78,25 @@ public class JsonTypeInfoTest extends TestBase
     }
 
     public void testWithRequireTypeIdForSubtypes() {
-        // Create an empty JsonTypeInfo.Value object
         JsonTypeInfo.Value empty = JsonTypeInfo.Value.EMPTY;
         assertNull(empty.getRequireTypeIdForSubtypes());
 
-        // Set requireTypeIdForSubtypes to OptBoolean.TRUE
         JsonTypeInfo.Value requireTypeIdTrue = empty.withRequireTypeIdForSubtypes(Boolean.TRUE);
         assertEquals(Boolean.TRUE, requireTypeIdTrue.getRequireTypeIdForSubtypes());
 
-        // Set requireTypeIdForSubtypes to OptBoolean.FALSE
         JsonTypeInfo.Value requireTypeIdFalse = empty.withRequireTypeIdForSubtypes(Boolean.FALSE);
         assertEquals(Boolean.FALSE, requireTypeIdFalse.getRequireTypeIdForSubtypes());
 
-        // Set requireTypeIdForSubtypes to OptBoolean.DEFAULT
         JsonTypeInfo.Value requireTypeIdDefault = empty.withRequireTypeIdForSubtypes(null);
         assertNull(requireTypeIdDefault.getRequireTypeIdForSubtypes());
     }
     
     public void testDefaultValueForRequireTypeIdForSubtypes() {
+        // default value
         JsonTypeInfo.Value v3 = JsonTypeInfo.Value.from(Anno3.class.getAnnotation(JsonTypeInfo.class));
         assertNull(v3.getRequireTypeIdForSubtypes());
         
-        // toString
+        // toString()
         assertEquals("JsonTypeInfo.Value(idType=NAME,includeAs=EXTERNAL_PROPERTY,propertyName=ext," 
                 + "defaultImpl=java.lang.Void,idVisible=false,requireTypeIdForSubtypes=null)", v3.toString());
     }


### PR DESCRIPTION
relates to #226