### PR TITLE
Merge forward JDK-6-compatible `equals()` and `hashcode()` implementations into `JsonTypeInfo.Value` of `master`

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonTypeInfo.java
@@ -460,8 +460,14 @@ public @interface JsonTypeInfo
 
         @Override
         public int hashCode() {
-            return Objects.hash(_idType, _inclusionType, _propertyName, _defaultImpl, _requireTypeIdForSubtypes)
-                + (_idVisible ? 11 : -17);
+            int hashCode = 1;
+            hashCode = 31 * hashCode + (_idType != null ? _idType.hashCode() : 0);
+            hashCode = 31 * hashCode + (_inclusionType != null ? _inclusionType.hashCode() : 0);
+            hashCode = 31 * hashCode + (_propertyName != null ? _propertyName.hashCode() : 0);
+            hashCode = 31 * hashCode + (_defaultImpl != null ? _defaultImpl.hashCode() : 0);
+            hashCode = 31 * hashCode + (_requireTypeIdForSubtypes ? 11 : -17);
+            hashCode = 31 * hashCode + (_idVisible ? 11 : -17);
+            return hashCode;
         }
 
         @Override
@@ -478,9 +484,20 @@ public @interface JsonTypeInfo
                     && (a._inclusionType == b._inclusionType)
                     && (a._defaultImpl == b._defaultImpl)
                     && (a._idVisible == b._idVisible)
-                    && Objects.equals(a._propertyName, b._propertyName)
-                    && Objects.equals(a._requireTypeIdForSubtypes, b._requireTypeIdForSubtypes)
+                    && _equal(a._propertyName, b._propertyName)
+                    && _equal(a._requireTypeIdForSubtypes, b._requireTypeIdForSubtypes)
             ;
+        }
+
+        private static <T> boolean _equal(T value1, T value2)
+        {
+            if (value1 == null) {
+                return (value2 == null);
+            }
+            if (value2 == null) {
+                return false;
+            }
+            return value1.equals(value2);
         }
     }
 }


### PR DESCRIPTION
### Motivation

This PR is for forwards-compatiblity with 3.0. As discussed in https://github.com/FasterXML/jackson-annotations/pull/229#discussion_r1197970359, same as title. I would like to see the implemenations to be "exactly" the same.

### Background

Originated from backporting `JsonTypeInfo.Value` of Jackson 3.0 into Jackson 2.16 in https://github.com/FasterXML/jackson-annotations/pull/229. The `equals()` and `hashcode()` implementations of `JsonTypeInfo.Value` in **Jackson 3.0 (master branch)** could not be directly copied because of its usage of JDK7 util methods `Objects.equals()` and `Objects.hashcode()` util methods, so ended up using the internal [Objects.hashcode()](https://github.com/openjdk/jdk/blob/cc5c9b5da2de4229c0244169bcbd6496f68db5ab/src/java.base/share/classes/java/util/Objects.java#L132-L134) implementation.

