### PR TITLE
Hash-pin GitHub Actions, set grouped dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,9 @@ jobs:
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java_version }}


### PR DESCRIPTION
As requested in https://github.com/FasterXML/jackson-core/pull/1103#issuecomment-1760732079.

This PR hash-pins GitHub Actions to improve workflow resilience. It also sets up dependabot grouped updates, so all new Actions are updated in a single PR.