### PR TITLE
Migrate tests to `JUnit 5` 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,11 +54,12 @@
   </properties>
 
   <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${version.junit}</version>
-      <scope>test</scope>
+    <!-- Test dependencies -->
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>5.9.1</version>
+        <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
   </properties>
 
   <dependencies>
-    <!-- Test dependencies -->
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>

--- a/src/test/java/com/fasterxml/jackson/annotation/FormatTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/FormatTest.java
@@ -11,7 +11,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests to verify that it is possibly to merge {@link JsonFormat.Value}
  * instances for overrides.
  */
-public class FormatTest {
+public class FormatTest
+{
     private final JsonFormat.Value EMPTY = JsonFormat.Value.empty();
 
     @JsonFormat(shape=JsonFormat.Shape.BOOLEAN, pattern="xyz", timezone="bogus")

--- a/src/test/java/com/fasterxml/jackson/annotation/FormatTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/FormatTest.java
@@ -3,17 +3,21 @@ package com.fasterxml.jackson.annotation;
 import com.fasterxml.jackson.annotation.JsonFormat.Feature;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 /**
  * Tests to verify that it is possibly to merge {@link JsonFormat.Value}
  * instances for overrides.
  */
-public class FormatTest extends TestBase
-{
+public class FormatTest {
     private final JsonFormat.Value EMPTY = JsonFormat.Value.empty();
 
     @JsonFormat(shape=JsonFormat.Shape.BOOLEAN, pattern="xyz", timezone="bogus")
     private final static class Bogus { }
 
+    @Test
     public void testEmptyInstanceDefaults() {
         JsonFormat.Value empty = JsonFormat.Value.empty();
         for (Feature f : Feature.values()) {
@@ -28,6 +32,7 @@ public class FormatTest extends TestBase
         assertFalse(empty.isLenient());
     }
 
+    @Test
     public void testEquality() {
         assertTrue(EMPTY.equals(EMPTY));
         assertTrue(new JsonFormat.Value().equals(new JsonFormat.Value()));
@@ -54,6 +59,7 @@ public class FormatTest extends TestBase
         assertFalse(v1.equals(v1.withoutFeature(Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)));
     }
 
+    @Test
     public void testToString() {
         assertEquals("JsonFormat.Value(pattern=,shape=STRING,lenient=null,locale=null,timezone=null,features=EMPTY)",
                 JsonFormat.Value.forShape(JsonFormat.Shape.STRING).toString());
@@ -61,6 +67,7 @@ public class FormatTest extends TestBase
                 JsonFormat.Value.forPattern("[.]").toString());
     }
 
+    @Test
     public void testFromAnnotation()
     {
         JsonFormat ann = Bogus.class.getAnnotation(JsonFormat.class);
@@ -74,6 +81,7 @@ public class FormatTest extends TestBase
         assertSame(EMPTY, JsonFormat.Value.from(null));
     }
 
+    @Test
     public void testSimpleMerge()
     {
         // Start with an empty instance
@@ -131,6 +139,7 @@ public class FormatTest extends TestBase
         assertFalse(merged.hasTimeZone());
     }
 
+    @Test
     public void testMultiMerge()
     {
         final String TEST_PATTERN = "format-string"; // not parsed, usage varies
@@ -148,6 +157,7 @@ public class FormatTest extends TestBase
     /**********************************************************
      */
 
+    @Test
     public void testLeniency() {
         JsonFormat.Value empty = JsonFormat.Value.empty();
         assertFalse(empty.hasLenient());
@@ -186,6 +196,7 @@ public class FormatTest extends TestBase
         assertFalse(dunno.equals(lenient));
     }
 
+    @Test
     public void testCaseInsensitiveValues() {
         JsonFormat.Value empty = JsonFormat.Value.empty();
         assertNull(empty.getFeature(Feature.ACCEPT_CASE_INSENSITIVE_VALUES));
@@ -197,6 +208,7 @@ public class FormatTest extends TestBase
         assertFalse(sensitive.getFeature(Feature.ACCEPT_CASE_INSENSITIVE_VALUES));
     }
 
+    @Test
     public void testShape() {
         assertFalse(JsonFormat.Shape.STRING.isNumeric());
         assertFalse(JsonFormat.Shape.STRING.isStructured());
@@ -209,6 +221,7 @@ public class FormatTest extends TestBase
         assertTrue(JsonFormat.Shape.OBJECT.isStructured());
     }
 
+    @Test
     public void testFeatures() {
         JsonFormat.Features f1 = JsonFormat.Features.empty();
         JsonFormat.Features f2 = f1.with(Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)

--- a/src/test/java/com/fasterxml/jackson/annotation/IncludeTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/IncludeTest.java
@@ -2,11 +2,15 @@ package com.fasterxml.jackson.annotation;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 /**
  * Tests to verify that it is possibly to merge {@link JsonInclude.Value}
  * instances for overrides
  */
-public class IncludeTest extends TestBase
+public class IncludeTest
 {
     private final JsonInclude.Value EMPTY = JsonInclude.Value.empty();
 
@@ -17,6 +21,7 @@ public class IncludeTest extends TestBase
             content=JsonInclude.Include.CUSTOM, contentFilter=Long.class)
     private final static class Custom { }
 
+    @Test
     public void testEquality() {
         assertTrue(EMPTY.equals(EMPTY));
 
@@ -33,6 +38,7 @@ public class IncludeTest extends TestBase
         assertFalse(v3.equals(v2));
     }
 
+    @Test
     public void testFromAnnotation()
     {
         JsonInclude ann = Bogus.class.getAnnotation(JsonInclude.class);
@@ -41,6 +47,7 @@ public class IncludeTest extends TestBase
         assertEquals(Include.NON_DEFAULT, v.getContentInclusion());
     }
 
+    @Test
     public void testFromAnnotationWithCustom()
     {
         JsonInclude ann = Custom.class.getAnnotation(JsonInclude.class);
@@ -55,6 +62,7 @@ public class IncludeTest extends TestBase
                 v.toString());
     }
 
+    @Test
     public void testStdOverrides() {
         assertEquals("JsonInclude.Value(value=NON_ABSENT,content=USE_DEFAULTS)",
                 JsonInclude.Value.construct(Include.NON_ABSENT, null).toString());
@@ -66,6 +74,7 @@ public class IncludeTest extends TestBase
         assertFalse(EMPTY.equals(""));
     }
 
+    @Test
     public void testSimpleMerge()
     {
         JsonInclude.Value empty = JsonInclude.Value.empty();
@@ -100,6 +109,7 @@ public class IncludeTest extends TestBase
     }
 
     // for [annotations#76]
+    @Test
     public void testContentMerge76()
     {
         JsonInclude.Value v1 = JsonInclude.Value.empty()
@@ -119,6 +129,7 @@ public class IncludeTest extends TestBase
         assertEquals(JsonInclude.Include.NON_ABSENT, v21.getValueInclusion());
     }
 
+    @Test
     public void testFilters()
     {
         JsonInclude.Value empty = JsonInclude.Value.empty();

--- a/src/test/java/com/fasterxml/jackson/annotation/JacksonInjectTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JacksonInjectTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JacksonInjectTest {
+public class JacksonInjectTest
+{
     private final static class Bogus {
         @JacksonInject(value="inject", useInput=OptBoolean.FALSE)
         public int field;

--- a/src/test/java/com/fasterxml/jackson/annotation/JacksonInjectTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JacksonInjectTest.java
@@ -1,7 +1,10 @@
 package com.fasterxml.jackson.annotation;
 
-public class JacksonInjectTest extends TestBase
-{
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JacksonInjectTest {
     private final static class Bogus {
         @JacksonInject(value="inject", useInput=OptBoolean.FALSE)
         public int field;
@@ -12,6 +15,7 @@ public class JacksonInjectTest extends TestBase
 
     private final JacksonInject.Value EMPTY = JacksonInject.Value.empty();
 
+    @Test
     public void testEmpty()
     {
         assertNull(EMPTY.getId());
@@ -24,6 +28,7 @@ public class JacksonInjectTest extends TestBase
         assertSame(EMPTY, JacksonInject.Value.construct("", null));
     }
 
+    @Test
     public void testFromAnnotation() throws Exception
     {
         assertSame(EMPTY, JacksonInject.Value.from(null)); // legal
@@ -42,6 +47,7 @@ public class JacksonInjectTest extends TestBase
         assertSame(EMPTY, v);
     }
 
+    @Test
     public void testStdMethods() {
         assertEquals("JacksonInject.Value(id=null,useInput=null)",
                 EMPTY.toString());
@@ -54,6 +60,7 @@ public class JacksonInjectTest extends TestBase
         assertFalse(EMPTY.equals("xyz"));
     }
 
+    @Test
     public void testFactories() throws Exception
     {
         JacksonInject.Value v = EMPTY.withId("name");

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonIgnorePropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonIgnorePropertiesTest.java
@@ -10,7 +10,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests to verify that it is possibly to merge {@link JsonIgnoreProperties.Value}
  * instances for overrides
  */
-public class JsonIgnorePropertiesTest {
+public class JsonIgnorePropertiesTest
+{
     @JsonIgnoreProperties(value={ "foo", "bar" }, ignoreUnknown=true)
     private final static class Bogus {
     }

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonIgnorePropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonIgnorePropertiesTest.java
@@ -2,18 +2,22 @@ package com.fasterxml.jackson.annotation;
 
 import java.util.*;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 /**
  * Tests to verify that it is possibly to merge {@link JsonIgnoreProperties.Value}
  * instances for overrides
  */
-public class JsonIgnorePropertiesTest extends TestBase
-{
+public class JsonIgnorePropertiesTest {
     @JsonIgnoreProperties(value={ "foo", "bar" }, ignoreUnknown=true)
     private final static class Bogus {
     }
 
     private final JsonIgnoreProperties.Value EMPTY = JsonIgnoreProperties.Value.empty();
 
+    @Test
     public void testEmpty() {
         // ok to try to create from null; gives empty
         assertSame(EMPTY, JsonIgnoreProperties.Value.from(null));
@@ -23,6 +27,7 @@ public class JsonIgnorePropertiesTest extends TestBase
         assertFalse(EMPTY.getAllowSetters());
     }
 
+    @Test
     public void testEquality() {
         assertEquals(EMPTY, EMPTY);
 
@@ -35,6 +40,7 @@ public class JsonIgnorePropertiesTest extends TestBase
         assertFalse(v.equals(EMPTY));
     }
 
+    @Test
     public void testFromAnnotation() throws Exception
     {
         JsonIgnoreProperties.Value v = JsonIgnoreProperties.Value.from(
@@ -48,6 +54,7 @@ public class JsonIgnorePropertiesTest extends TestBase
         assertEquals(_set("foo", "bar"), ign);
     }
 
+    @Test
     public void testFactories() {
         assertSame(EMPTY, JsonIgnoreProperties.Value.forIgnoreUnknown(false));
         assertSame(EMPTY, JsonIgnoreProperties.Value.forIgnoredProperties());
@@ -71,6 +78,7 @@ public class JsonIgnorePropertiesTest extends TestBase
         assertEquals(_set("a", "b"), vdeser.findIgnoredForSerialization());
     }
 
+    @Test
     public void testMutantFactories()
     {
         assertEquals(2, EMPTY.withIgnored("a", "b").getIgnored().size());
@@ -89,6 +97,7 @@ public class JsonIgnorePropertiesTest extends TestBase
         assertFalse(EMPTY.withoutMerge().getMerge());
     }
 
+    @Test
     public void testSimpleMerge()
     {
         JsonIgnoreProperties.Value v1 = EMPTY.withIgnoreUnknown().withAllowGetters();
@@ -117,6 +126,7 @@ public class JsonIgnorePropertiesTest extends TestBase
         assertSame(v2b, v2b.withOverrides(EMPTY));
     }
 
+    @Test
     public void testMergeIgnoreProperties()
     {
         JsonIgnoreProperties.Value v1 = EMPTY.withIgnored("a");
@@ -131,6 +141,7 @@ public class JsonIgnorePropertiesTest extends TestBase
         assertTrue(all.contains("c"));
     }
 
+    @Test
     public void testToString() {
         assertEquals(
                 "JsonIgnoreProperties.Value(ignored=[],ignoreUnknown=false,allowGetters=false,allowSetters=true,merge=true)",

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
@@ -1,16 +1,16 @@
 package com.fasterxml.jackson.annotation;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests to verify that it is possibly to merge {@link JsonIncludeProperties.Value}
  * instances for overrides
  */
-public class JsonIncludePropertiesTest extends TestBase
-{
+public class JsonIncludePropertiesTest {
     @JsonIncludeProperties(value = {"foo", "bar"})
     private final static class Bogus
     {
@@ -18,6 +18,7 @@ public class JsonIncludePropertiesTest extends TestBase
 
     private final JsonIncludeProperties.Value ALL = JsonIncludeProperties.Value.all();
 
+    @Test
     public void testAll()
     {
         assertSame(ALL, JsonIncludeProperties.Value.from(null));
@@ -27,6 +28,7 @@ public class JsonIncludePropertiesTest extends TestBase
         assertEquals(0, ALL.hashCode());
     }
 
+    @Test
     public void testFromAnnotation()
     {
         JsonIncludeProperties.Value v = JsonIncludeProperties.Value.from(Bogus.class.getAnnotation(JsonIncludeProperties.class));
@@ -41,6 +43,7 @@ public class JsonIncludePropertiesTest extends TestBase
         assertEquals(v, JsonIncludeProperties.Value.from(Bogus.class.getAnnotation(JsonIncludeProperties.class)));
     }
 
+    @Test
     public void testWithOverridesAll() {
         JsonIncludeProperties.Value v = JsonIncludeProperties.Value.from(Bogus.class.getAnnotation(JsonIncludeProperties.class));
         v = v.withOverrides(ALL);
@@ -49,6 +52,7 @@ public class JsonIncludePropertiesTest extends TestBase
         assertEquals(_set("foo", "bar"), included);
     }
 
+    @Test
     public void testWithOverridesEmpty() {
         JsonIncludeProperties.Value v = JsonIncludeProperties.Value.from(Bogus.class.getAnnotation(JsonIncludeProperties.class));
         v = v.withOverrides(new JsonIncludeProperties.Value(Collections.<String>emptySet()));
@@ -56,6 +60,7 @@ public class JsonIncludePropertiesTest extends TestBase
         assertEquals(0, included.size());
     }
 
+    @Test
     public void testWithOverridesMerge() {
         JsonIncludeProperties.Value v = JsonIncludeProperties.Value.from(Bogus.class.getAnnotation(JsonIncludeProperties.class));
         v = v.withOverrides(new JsonIncludeProperties.Value(_set("foo")));

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonIncludePropertiesTest.java
@@ -10,7 +10,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests to verify that it is possibly to merge {@link JsonIncludeProperties.Value}
  * instances for overrides
  */
-public class JsonIncludePropertiesTest {
+public class JsonIncludePropertiesTest
+{
     @JsonIncludeProperties(value = {"foo", "bar"})
     private final static class Bogus
     {

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonSetterTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonSetterTest.java
@@ -1,7 +1,10 @@
 package com.fasterxml.jackson.annotation;
 
-public class JsonSetterTest extends TestBase
-{
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JsonSetterTest {
     private final static class Bogus {
         @JsonSetter(nulls=Nulls.FAIL, contentNulls=Nulls.SKIP)
         public int field;
@@ -9,6 +12,7 @@ public class JsonSetterTest extends TestBase
 
     private final JsonSetter.Value EMPTY = JsonSetter.Value.empty();
 
+    @Test
     public void testEmpty()
     {
         assertEquals(Nulls.DEFAULT, EMPTY.getValueNulls());
@@ -20,6 +24,7 @@ public class JsonSetterTest extends TestBase
         assertNull(EMPTY.nonDefaultContentNulls());
     }
 
+    @Test
     public void testStdMethods() {
         assertEquals("JsonSetter.Value(valueNulls=DEFAULT,contentNulls=DEFAULT)",
                 EMPTY.toString());
@@ -32,6 +37,7 @@ public class JsonSetterTest extends TestBase
         assertFalse(EMPTY.equals("xyz"));
     }
 
+    @Test
     public void testFromAnnotation() throws Exception
     {
         assertSame(EMPTY, JsonSetter.Value.from(null)); // legal
@@ -42,12 +48,14 @@ public class JsonSetterTest extends TestBase
         assertEquals(Nulls.SKIP, v.getContentNulls());
     }
 
+    @Test
     public void testConstruct() throws Exception
     {
         JsonSetter.Value v = JsonSetter.Value.construct(null, null);
         assertSame(EMPTY, v);
     }
 
+    @Test
     public void testFactories() throws Exception
     {
         JsonSetter.Value v = JsonSetter.Value.forContentNulls(Nulls.SET);
@@ -61,6 +69,7 @@ public class JsonSetterTest extends TestBase
         assertEquals(Nulls.SKIP, skip.nonDefaultValueNulls());
     }
 
+    @Test
     public void testSimpleMerge()
     {
         JsonSetter.Value v = EMPTY.withContentNulls(Nulls.SKIP);
@@ -69,6 +78,7 @@ public class JsonSetterTest extends TestBase
         assertEquals(Nulls.FAIL, v.getValueNulls());
     }
 
+    @Test
     public void testWithMethods()
     {
         JsonSetter.Value v = EMPTY.withContentNulls(null);

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonSetterTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonSetterTest.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JsonSetterTest {
+public class JsonSetterTest
+{
     private final static class Bogus {
         @JsonSetter(nulls=Nulls.FAIL, contentNulls=Nulls.SKIP)
         public int field;

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonTypeInfoTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonTypeInfoTest.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JsonTypeInfoTest {
+public class JsonTypeInfoTest
+{
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, visible=true,
             defaultImpl = JsonTypeInfo.class, requireTypeIdForSubtypes = OptBoolean.TRUE)
     private final static class Anno1 { }

--- a/src/test/java/com/fasterxml/jackson/annotation/JsonTypeInfoTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/JsonTypeInfoTest.java
@@ -2,8 +2,11 @@ package com.fasterxml.jackson.annotation;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 
-public class JsonTypeInfoTest extends TestBase
-{
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JsonTypeInfoTest {
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, visible=true,
             defaultImpl = JsonTypeInfo.class, requireTypeIdForSubtypes = OptBoolean.TRUE)
     private final static class Anno1 { }
@@ -17,12 +20,14 @@ public class JsonTypeInfoTest extends TestBase
             property = "ext",
             defaultImpl = Void.class)
     private final static class Anno3 { }
-    
+
+    @Test
     public void testEmpty() {
         // 07-Mar-2017, tatu: Important to distinguish "none" from 'empty' value...
         assertNull(JsonTypeInfo.Value.from(null));
     }
 
+    @Test
     public void testFromAnnotation() throws Exception
     {
         JsonTypeInfo.Value v1 = JsonTypeInfo.Value.from(Anno1.class.getAnnotation(JsonTypeInfo.class));
@@ -53,6 +58,7 @@ public class JsonTypeInfoTest extends TestBase
         assertEquals("JsonTypeInfo.Value(idType=NAME,includeAs=EXTERNAL_PROPERTY,propertyName=ext,defaultImpl=java.lang.Void,idVisible=false,requireTypeIdForSubtypes=false)", v2.toString());
     }
 
+    @Test
     public void testMutators() throws Exception
     {
         JsonTypeInfo.Value v = JsonTypeInfo.Value.from(Anno1.class.getAnnotation(JsonTypeInfo.class));
@@ -79,6 +85,7 @@ public class JsonTypeInfoTest extends TestBase
         assertEquals("foobar", v.withPropertyName("foobar").getPropertyName());
     }
 
+    @Test
     public void testWithRequireTypeIdForSubtypes() {
         JsonTypeInfo.Value empty = JsonTypeInfo.Value.EMPTY;
         assertNull(empty.getRequireTypeIdForSubtypes());
@@ -92,7 +99,8 @@ public class JsonTypeInfoTest extends TestBase
         JsonTypeInfo.Value requireTypeIdDefault = empty.withRequireTypeIdForSubtypes(null);
         assertNull(requireTypeIdDefault.getRequireTypeIdForSubtypes());
     }
-    
+
+    @Test
     public void testDefaultValueForRequireTypeIdForSubtypes() {
         // default value
         JsonTypeInfo.Value v3 = JsonTypeInfo.Value.from(Anno3.class.getAnnotation(JsonTypeInfo.class));

--- a/src/test/java/com/fasterxml/jackson/annotation/ObjectIdStuffTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/ObjectIdStuffTest.java
@@ -2,9 +2,13 @@ package com.fasterxml.jackson.annotation;
 
 import java.util.UUID;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 // Test mostly to keep code coverage decent
-public class ObjectIdStuffTest extends TestBase
-{
+public class ObjectIdStuffTest {
+    @Test
     public void testObjectIdGenerator()
     {
         ObjectIdGenerator.IdKey k = new ObjectIdGenerator.IdKey(String.class, Object.class, "id1");
@@ -21,6 +25,7 @@ public class ObjectIdStuffTest extends TestBase
         assertFalse(k2.equals(k));
     }
 
+    @Test
     public void testIntSequenceGenerator()
     {
         ObjectIdGenerators.IntSequenceGenerator gen = new ObjectIdGenerators.IntSequenceGenerator();
@@ -30,6 +35,7 @@ public class ObjectIdStuffTest extends TestBase
         assertEquals(Integer.valueOf(0), id);
     }
 
+    @Test
     public void testStringIdGenerator()
     {
         ObjectIdGenerators.StringIdGenerator gen = new ObjectIdGenerators.StringIdGenerator();
@@ -37,6 +43,7 @@ public class ObjectIdStuffTest extends TestBase
         assertNotNull(id);
     }
 
+    @Test
     public void testUUIDGenerator()
     {
         ObjectIdGenerators.UUIDGenerator gen = new ObjectIdGenerators.UUIDGenerator();

--- a/src/test/java/com/fasterxml/jackson/annotation/ObjectIdStuffTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/ObjectIdStuffTest.java
@@ -7,7 +7,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 // Test mostly to keep code coverage decent
-public class ObjectIdStuffTest {
+public class ObjectIdStuffTest
+{
     @Test
     public void testObjectIdGenerator()
     {

--- a/src/test/java/com/fasterxml/jackson/annotation/OptBooleanTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/OptBooleanTest.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 // Silly test for OptBoolean, for code coverage
-public class OptBooleanTest {
+public class OptBooleanTest
+{
     @Test
     public void testProperties()
     {

--- a/src/test/java/com/fasterxml/jackson/annotation/OptBooleanTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/OptBooleanTest.java
@@ -1,8 +1,12 @@
 package com.fasterxml.jackson.annotation;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 // Silly test for OptBoolean, for code coverage
-public class OptBooleanTest extends TestBase
-{
+public class OptBooleanTest {
+    @Test
     public void testProperties()
     {
         assertTrue(OptBoolean.TRUE.asPrimitive());

--- a/src/test/java/com/fasterxml/jackson/annotation/PropertyAccessorTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/PropertyAccessorTest.java
@@ -1,8 +1,12 @@
 package com.fasterxml.jackson.annotation;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 // Silly test for PropertyAccessor, for code coverage
-public class PropertyAccessorTest extends TestBase
-{
+public class PropertyAccessorTest {
+    @Test
     public void testProperties()
     {
         assertTrue(PropertyAccessor.ALL.creatorEnabled());

--- a/src/test/java/com/fasterxml/jackson/annotation/PropertyAccessorTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/PropertyAccessorTest.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 // Silly test for PropertyAccessor, for code coverage
-public class PropertyAccessorTest {
+public class PropertyAccessorTest
+{
     @Test
     public void testProperties()
     {

--- a/src/test/java/com/fasterxml/jackson/annotation/TestBase.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/TestBase.java
@@ -1,7 +1,0 @@
-package com.fasterxml.jackson.annotation;
-
-import junit.framework.TestCase;
-
-public abstract class TestBase extends TestCase
-{
-}

--- a/src/test/java/com/fasterxml/jackson/annotation/VisibilityTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/VisibilityTest.java
@@ -4,9 +4,12 @@ import java.lang.reflect.Member;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 // Silly test for JsonAutoDetect.Visibility type, for code coverage
-public class VisibilityTest extends TestBase
-{
+public class VisibilityTest {
     static class Bogus {
         public String value;
     }
@@ -21,6 +24,7 @@ public class VisibilityTest extends TestBase
     private final static JsonAutoDetect.Value NO_OVERRIDES = JsonAutoDetect.Value.noOverrides();
     private final static JsonAutoDetect.Value DEFAULTS = JsonAutoDetect.Value.defaultVisibility();
 
+    @Test
     public void testAnnotationProperties() throws Exception
     {
         Member m = Bogus.class.getField("value");
@@ -37,6 +41,7 @@ public class VisibilityTest extends TestBase
         assertFalse(JsonAutoDetect.Visibility.DEFAULT.isVisible(m));
     }
 
+    @Test
     public void testBasicValueProperties() {
         JsonAutoDetect.Value v = JsonAutoDetect.Value.DEFAULT;
         assertEquals(JsonAutoDetect.class, v.valueFor());
@@ -53,6 +58,7 @@ public class VisibilityTest extends TestBase
         assertFalse(v.equals("foo"));
     }
 
+    @Test
     public void testEquality() {
         assertEquals(NO_OVERRIDES, NO_OVERRIDES);
         assertEquals(DEFAULTS, DEFAULTS);
@@ -60,6 +66,7 @@ public class VisibilityTest extends TestBase
         assertFalse(NO_OVERRIDES.equals(DEFAULTS));
     }
 
+    @Test
     public void testFromAnnotation()
     {
         JsonAutoDetect ann = Custom.class.getAnnotation(JsonAutoDetect.class);
@@ -76,6 +83,7 @@ public class VisibilityTest extends TestBase
         assertEquals(ann.creatorVisibility(), v.getCreatorVisibility());
     }
 
+    @Test
     public void testToString() {
         assertEquals(
 "JsonAutoDetect.Value(fields=PUBLIC_ONLY,getters=PUBLIC_ONLY,"+
@@ -87,6 +95,7 @@ public class VisibilityTest extends TestBase
                 JsonAutoDetect.Value.noOverrides().toString());
     }
 
+    @Test
     public void testSimpleMerge() {
         JsonAutoDetect.Value base = JsonAutoDetect.Value.construct(
                 Visibility.ANY,
@@ -124,6 +133,7 @@ public class VisibilityTest extends TestBase
         assertSame(overrides, JsonAutoDetect.Value.merge(overrides, null));
     }
 
+    @Test
     public void testFactoryMethods() {
         JsonAutoDetect.Value v = JsonAutoDetect.Value.construct(PropertyAccessor.FIELD,
                 Visibility.ANY);
@@ -142,6 +152,7 @@ public class VisibilityTest extends TestBase
         assertEquals(Visibility.NONE, all.getCreatorVisibility());
     }
 
+    @Test
     public void testSimpleChanges() {
         assertSame(NO_OVERRIDES, NO_OVERRIDES.withFieldVisibility(Visibility.DEFAULT));
         JsonAutoDetect.Value v = NO_OVERRIDES.withCreatorVisibility(Visibility.PUBLIC_ONLY);

--- a/src/test/java/com/fasterxml/jackson/annotation/VisibilityTest.java
+++ b/src/test/java/com/fasterxml/jackson/annotation/VisibilityTest.java
@@ -9,7 +9,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 // Silly test for JsonAutoDetect.Visibility type, for code coverage
-public class VisibilityTest {
+public class VisibilityTest
+{
     static class Bogus {
         public String value;
     }


### PR DESCRIPTION
resolves #247 

Moving forward (including 3.x), let's start using `Junit 5`