### PR TITLE
Remove redundant no-arg constructor

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/PropertyAccessor.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/PropertyAccessor.java
@@ -63,8 +63,6 @@ public enum PropertyAccessor
     ALL
     ;
 
-    private PropertyAccessor() { }
-
     public boolean creatorEnabled() {
         return (this == CREATOR) || (this == ALL);
     }


### PR DESCRIPTION
Kindly review and advise if this makes sense to merge into 2.15 or whether it should go straight to 2.18 and 3.x