### PR TITLE
Update `@JsonFormat` javaDoc regarding `LocalDate` usage.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java
@@ -22,6 +22,11 @@ import java.util.TimeZone;
  * <li>{@link java.util.Date}: Shape can  be {@link Shape#STRING} or {@link Shape#NUMBER};
  *    pattern may contain {@link java.text.SimpleDateFormat}-compatible pattern definition.
  *   </li>
+ * <li>{@code java.time.*}: Types in the {@code java.time} package can use
+ *    {@link Shape#STRING} for serialization and deserialization. When {@link Shape#STRING}
+ *    is used, the pattern property typically follows
+ *    {@link java.time.format.DateTimeFormatter}-compatible formatting rules.
+ *   </li>
  * <li>Can be used on Classes (types) as well, for modified default behavior, possibly
  *   overridden by per-property annotation
  *   </li>

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonFormat.java
@@ -17,9 +17,9 @@ import java.util.TimeZone;
  * or String (such as ISO-8601 compatible time value) -- as well as configuring
  * exact details with {@link #pattern} property.
  *<p>
- * As of Jackson 2.6, known special handling includes:
+ * As of Jackson 2.18, known special handling includes:
  *<ul>
- * <li>{@link java.util.Date}: Shape can  be {@link Shape#STRING} or {@link Shape#NUMBER};
+ * <li>{@link java.util.Date} or {@link java.util.Calendar} : Shape can  be {@link Shape#STRING} or {@link Shape#NUMBER};
  *    pattern may contain {@link java.text.SimpleDateFormat}-compatible pattern definition.
  *   </li>
  * <li>{@code java.time.*}: Types in the {@code java.time} package can use


### PR DESCRIPTION
Resolves [jackson-modules-java8#330](https://github.com/FasterXML/jackson-modules-java8/issues/330)