### PR TITLE
Fix #296: drop Java 6/JDK 1.6 compatibility (now Java 8)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Alas, as long as JDK6 is target, cannot run against 14+
-        java_version: ['8', '11']
+        java_version: ['8', '17', '21', '24']
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,9 @@
   <properties>
     <!-- 04-Mar-2019, tatu: Retain Java6/JDK1.6 compatibility for annotations for Jackson 2.x,
              but use Moditect to get JDK9+ module info support; need newer bundle plugin as well
+    -->
+    <!-- 10-Jul-2025, tatu: Time to move on; leave at defaults for Java/JDK 8
       -->
-    <javac.src.version>1.6</javac.src.version>
-    <javac.target.version>1.6</javac.target.version>
-
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
-
     <osgi.export>com.fasterxml.jackson.annotation.*;version=${project.version}</osgi.export>
 
     <!-- for Reproducible Builds -->

--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -17,6 +17,7 @@ NOTE: Jackson 3.x components rely on 2.x annotations; there are no separate
 2.20 (not yet released)
 
 #294: Drop patch number from version for 2.20 and later (no more 2.20.0)
+#296: Drop Java 6 compatibility for 2.20 (Java 8 baseline)
 
 2.19.1 (13-Jun-2025)
 


### PR DESCRIPTION
Fixes #296: JDK 8 as baseline.