### PR TITLE
Fix to remove BOM alignment wrt upcoming 3.x changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,15 +182,9 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <platformDependencies>
-            <dependency>
-              <groupId>com.fasterxml.jackson</groupId>
-              <artifactId>jackson-bom</artifactId>
-              <version>${project.version}</version>
-            </dependency>
-          </platformDependencies>
-        </configuration>
+        <!-- 15-Jul-2025, tatu: With annotations 2.x used for both 2.x AND
+               3.x should not try to force alignment
+          -->
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
cc @jjohannes As per your suggestion, dropping from 2.20 (3.0 will rely on that version)