### PR TITLE
Add `JsonInclude.Value` convenience constants

### DIFF
--- a/release-notes/VERSION-2.x
+++ b/release-notes/VERSION-2.x
@@ -16,7 +16,8 @@ NOTE: Jackson 3.x components rely on 2.x annotations; there are no separate
 
 2.21 (not yet released)
 
-No changes since 2.20
+#314: Add `JsonInclude.Value` convenience constants
+ (contributed by @runeflobakk)
 
 2.20 (28-Aug-2025)
 

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonInclude.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonInclude.java
@@ -271,6 +271,8 @@ public @interface JsonInclude
         /**
          * Value that indicates that property is to be always included,
          * independent of value of the property.
+         *
+         * @since 2.21
          */
         public final static Value ALL_ALWAYS = Value
                 .construct(Include.ALWAYS, Include.ALWAYS);
@@ -278,6 +280,8 @@ public @interface JsonInclude
         /**
          * Value that indicates that only properties with non-null
          * values are to be included.
+         *
+         * @since 2.21
          */
         public final static Value ALL_NON_NULL = Value
                 .construct(Include.NON_NULL, Include.NON_NULL);
@@ -292,6 +296,8 @@ public @interface JsonInclude
          *     that would not deference to a non-null value.
          * </ul>
          * This option is mostly used to work with "Optional"s (Java 8, Guava).
+         *
+         * @since 2.21
          */
         public final static Value ALL_NON_ABSENT = Value
                 .construct(Include.NON_ABSENT, Include.NON_ABSENT);
@@ -300,6 +306,8 @@ public @interface JsonInclude
          * Value that indicates that only properties with null value,
          * or what is considered empty, are not to be included.
          * See {@link Include#NON_EMPTY} for further details.
+         *
+         * @since 2.21
          */
         public final static Value ALL_NON_EMPTY = Value
                 .construct(Include.NON_EMPTY, Include.NON_EMPTY);
@@ -307,6 +315,8 @@ public @interface JsonInclude
         /**
          * The equivalent to {@link Include#NON_DEFAULT} for specifying
          * inclusion of non-defaults for both values and content.
+         *
+         * @since 2.21
          */
         public final static Value ALL_NON_DEFAULT = Value
                 .construct(Include.NON_DEFAULT, Include.NON_DEFAULT);

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonInclude.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonInclude.java
@@ -269,13 +269,13 @@ public @interface JsonInclude
         private static final long serialVersionUID = 1L;
 
         /**
-         * Value that indicates that property is to be always included,
+         * Constant that indicates that property is to be always included,
          * independent of value of the property.
          * <p>
          * This will specify the same setting for including a value both
          * on <b>Java object level</b> as well as when <b>contained</b>
          * in an object reference (see {@link JsonInclude} for further
-         * details on this distinction)
+         * details on this distinction).
          *
          * @since 2.21
          */
@@ -283,13 +283,13 @@ public @interface JsonInclude
                 .construct(Include.ALWAYS, Include.ALWAYS);
 
         /**
-         * Value that indicates that only properties with non-null
+         * Constant that indicates that only properties with non-null
          * values are to be included.
          * <p>
          * This will specify the same setting for including a value both
          * on <b>Java object level</b> as well as when <b>contained</b>
          * in an object reference (see {@link JsonInclude} for further
-         * details on this distinction)
+         * details on this distinction).
          *
          * @since 2.21
          */
@@ -297,7 +297,7 @@ public @interface JsonInclude
                 .construct(Include.NON_NULL, Include.NON_NULL);
 
         /**
-         * Value that indicates that properties are included unless their value
+         * Constant that indicates that properties are included unless their value
          * is:
          * <ul>
          *  <li>null</li>
@@ -310,7 +310,7 @@ public @interface JsonInclude
          * This will specify the same setting for including a value both
          * on <b>Java object level</b> as well as when <b>contained</b>
          * in an object reference (see {@link JsonInclude} for further
-         * details on this distinction)
+         * details on this distinction).
          *
          * @since 2.21
          */
@@ -318,14 +318,14 @@ public @interface JsonInclude
                 .construct(Include.NON_ABSENT, Include.NON_ABSENT);
 
         /**
-         * Value that indicates that only properties with null value,
+         * Constant that indicates that only properties with null value,
          * or what is considered empty, are not to be included.
          * See {@link Include#NON_EMPTY} for further details.
          * <p>
          * This will specify the same setting for including a value both
          * on <b>Java object level</b> as well as when <b>contained</b>
          * in an object reference (see {@link JsonInclude} for further
-         * details on this distinction)
+         * details on this distinction).
          *
          * @since 2.21
          */
@@ -339,7 +339,7 @@ public @interface JsonInclude
          * This will specify the same setting for including a value both
          * on <b>Java object level</b> as well as when <b>contained</b>
          * in an object reference (see {@link JsonInclude} for further
-         * details on this distinction)
+         * details on this distinction).
          *
          * @since 2.21
          */

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonInclude.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonInclude.java
@@ -271,6 +271,11 @@ public @interface JsonInclude
         /**
          * Value that indicates that property is to be always included,
          * independent of value of the property.
+         * <p>
+         * This will specify the same setting for including a value both
+         * on <b>Java object level</b> as well as when <b>contained</b>
+         * in an object reference (see {@link JsonInclude} for further
+         * details on this distinction)
          *
          * @since 2.21
          */
@@ -280,6 +285,11 @@ public @interface JsonInclude
         /**
          * Value that indicates that only properties with non-null
          * values are to be included.
+         * <p>
+         * This will specify the same setting for including a value both
+         * on <b>Java object level</b> as well as when <b>contained</b>
+         * in an object reference (see {@link JsonInclude} for further
+         * details on this distinction)
          *
          * @since 2.21
          */
@@ -296,6 +306,11 @@ public @interface JsonInclude
          *     that would not deference to a non-null value.
          * </ul>
          * This option is mostly used to work with "Optional"s (Java 8, Guava).
+         * <p>
+         * This will specify the same setting for including a value both
+         * on <b>Java object level</b> as well as when <b>contained</b>
+         * in an object reference (see {@link JsonInclude} for further
+         * details on this distinction)
          *
          * @since 2.21
          */
@@ -306,6 +321,11 @@ public @interface JsonInclude
          * Value that indicates that only properties with null value,
          * or what is considered empty, are not to be included.
          * See {@link Include#NON_EMPTY} for further details.
+         * <p>
+         * This will specify the same setting for including a value both
+         * on <b>Java object level</b> as well as when <b>contained</b>
+         * in an object reference (see {@link JsonInclude} for further
+         * details on this distinction)
          *
          * @since 2.21
          */
@@ -315,6 +335,11 @@ public @interface JsonInclude
         /**
          * The equivalent to {@link Include#NON_DEFAULT} for specifying
          * inclusion of non-defaults for both values and content.
+         * <p>
+         * This will specify the same setting for including a value both
+         * on <b>Java object level</b> as well as when <b>contained</b>
+         * in an object reference (see {@link JsonInclude} for further
+         * details on this distinction)
          *
          * @since 2.21
          */

--- a/src/main/java/com/fasterxml/jackson/annotation/JsonInclude.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonInclude.java
@@ -262,6 +262,49 @@ public @interface JsonInclude
     {
         private static final long serialVersionUID = 1L;
 
+        /**
+         * Value that indicates that property is to be always included,
+         * independent of value of the property.
+         */
+        public final static Value ALL_ALWAYS = Value
+                .construct(Include.ALWAYS, Include.ALWAYS);
+
+        /**
+         * Value that indicates that only properties with non-null
+         * values are to be included.
+         */
+        public final static Value ALL_NON_NULL = Value
+                .construct(Include.NON_NULL, Include.NON_NULL);
+
+        /**
+         * Value that indicates that properties are included unless their value
+         * is:
+         * <ul>
+         *  <li>null</li>
+         *  <li>"absent" value of a referential type (like Java 8 `Optional`, or
+         *     {@link java.util.concurrent.atomic.AtomicReference}); that is, something
+         *     that would not deference to a non-null value.
+         * </ul>
+         * This option is mostly used to work with "Optional"s (Java 8, Guava).
+         */
+        public final static Value ALL_NON_ABSENT = Value
+                .construct(Include.NON_ABSENT, Include.NON_ABSENT);
+
+        /**
+         * Value that indicates that only properties with null value,
+         * or what is considered empty, are not to be included.
+         * See {@link Include#NON_EMPTY} for further details.
+         */
+        public final static Value ALL_NON_EMPTY = Value
+                .construct(Include.NON_EMPTY, Include.NON_EMPTY);
+
+        /**
+         * The equivalent to {@link Include#NON_DEFAULT} for specifying
+         * inclusion of non-defaults for both values and content.
+         */
+        public final static Value ALL_NON_DEFAULT = Value
+                .construct(Include.NON_DEFAULT, Include.NON_DEFAULT);
+
         protected final static Value EMPTY = new Value(Include.USE_DEFAULTS,
                 Include.USE_DEFAULTS, null, null);
 


### PR DESCRIPTION
See discussion here: https://github.com/FasterXML/jackson-databind/discussions/5294

This pull-request adds some constants to `JsonInclude.Value` equivalent to the enum values of `JsonInclude.Include`.

This e.g enables the following for configuring a JsonMapper:
```java
var jsonMapper = JsonMapper.builder()
    .defaultPropertyInclusion(JsonInclude.Value.ALL_NON_NULL)
    .build();
```


I noticed a kind of established pattern in `JsonInclude.Value` to declare `static final` constants as `protected`, and use a static _method_ to access it. If this pattern is also applicable for these constants, just let me know, and I will edit the pull-request accordingly!