### PR TITLE
Clarify @JsonInclude handling and module responsibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Project is licensed under [Apache License 2.0](http://www.apache.org/licenses/LI
 [![Tidelift](https://tidelift.com/badges/package/maven/com.fasterxml.jackson.core:jackson-annotations)](https://tidelift.com/subscription/pkg/maven-com-fasterxml-jackson-core-jackson-annotations?utm_source=maven-com-fasterxml-jackson-core-jackson-annotations&utm_medium=referral&utm_campaign=readme)
 [![OpenSSF  Scorecard](https://api.securityscorecards.dev/projects/github.com/FasterXML/jackson-annotations/badge)](https://securityscorecards.dev/viewer/?uri=github.com/FasterXML/jackson-annotations)
 
+
+### Note on annotation handling
+
+This module only defines Jackson annotations and their basic semantics.
+Actual handling and interpretation of annotations (such as inclusion rules,
+container content handling, or Optional value processing) is implemented
+by jackson-databind.
+
+As a result, certain annotation attributes (for example `content` inclusion
+settings on `@JsonInclude`) may only be fully applied when used at the
+property level, depending on databind behavior.
+
 -----
 
 ## Release notes

--- a/README.md
+++ b/README.md
@@ -26,11 +26,7 @@ Project is licensed under [Apache License 2.0](http://www.apache.org/licenses/LI
 This module only defines Jackson annotations and their basic semantics.
 Actual handling and interpretation of annotations (such as inclusion rules,
 container content handling, or Optional value processing) is implemented
-by jackson-databind.
-
-As a result, certain annotation attributes (for example `content` inclusion
-settings on `@JsonInclude`) may only be fully applied when used at the
-property level, depending on databind behavior.
+by [jackson-databind](https://github.com/FasterXML/jackson-databind).
 
 -----
 


### PR DESCRIPTION
This PR adds a small clarification to the jackson-annotations README
explaining that annotations only define intent, while actual handling
(such as content inclusion behavior) is implemented by jackson-databind.

This aims to reduce confusion around class-level vs property-level
@JsonInclude behavior.

Related to FasterXML/jackson-databind#5548

Note: I previously opened this as a PR against my fork by mistake.
This PR targets the upstream FasterXML/jackson-annotations (2.x) branch as intended.
