### PR TITLE
#335: Enhance target of JsonPropertyDescription

### DIFF
--- a/src/main/java/com/fasterxml/jackson/annotation/JsonPropertyDescription.java
+++ b/src/main/java/com/fasterxml/jackson/annotation/JsonPropertyDescription.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
  *
  * @since 2.3
  */
-@Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.RECORD_COMPONENT})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented // since 2.6
 @JacksonAnnotation


### PR DESCRIPTION
Added `RECORD_COMPONENT` as target type for `JsonPropertyDescription` for https://github.com/FasterXML/jackson-annotations/issues/335.