### PR TITLE
docs:update README, SECURITY, and docs links to canonical URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Project contains versions 2.0 and above: source code for earlier (1.x) versions 
 [Full Listing of Jackson Annotations](../../wiki/Jackson-Annotations) details all available annotations;
 [Project Wiki](../../wiki) gives more details.
 
-Project is licensed under [Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+Project is licensed under [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
 [![Build (github)](https://github.com/FasterXML/jackson-annotations/actions/workflows/main.yml/badge.svg)](https://github.com/FasterXML/jackson-annotations/actions/workflows/main.yml)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.core/jackson-annotations/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.fasterxml.jackson.core/jackson-annotations)
-[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.core/jackson-annotations.svg)](http://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-annotations)
+[![Maven Central](https://img.shields.io/maven-central/v/com.fasterxml.jackson.core/jackson-annotations.svg)](https://central.sonatype.com/artifact/com.fasterxml.jackson.core/jackson-annotations)
+[![Javadoc](https://javadoc.io/badge/com.fasterxml.jackson.core/jackson-annotations.svg)](https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-annotations)
 [![Tidelift](https://tidelift.com/badges/package/maven/com.fasterxml.jackson.core:jackson-annotations)](https://tidelift.com/subscription/pkg/maven-com-fasterxml-jackson-core-jackson-annotations?utm_source=maven-com-fasterxml-jackson-core-jackson-annotations&utm_medium=referral&utm_campaign=readme)
 [![OpenSSF  Scorecard](https://api.securityscorecards.dev/projects/github.com/FasterXML/jackson-annotations/badge)](https://securityscorecards.dev/viewer/?uri=github.com/FasterXML/jackson-annotations)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Last Updated: 2022-09-20
 In unlikely event of finding a security vulnerability directly relating to `jackson-annotations`
 package -- unlikely, as there is very little code in this package --
 the recommended mechanism for reporting possible security vulnerabilities follows
-so-called "Coordinated Disclosure Plan" (see [definition of DCP](https://vuls.cert.org/confluence/display/Wiki/Coordinated+Vulnerability+Disclosure+Guidance)
+so-called "Coordinated Disclosure Plan" (see [definition of DCP](https://certcc.github.io/confluence/display/Wiki/Coordinated+Vulnerability+Disclosure+Guidance/)
 for general idea). The first step is to file a [Tidelift security contact](https://tidelift.com/security):
 Tidelift will route all reports via their system to maintainers of relevant package(s), and start the
 process that will evaluate concern and issue possible fixes, send update notices and so on.
@@ -19,6 +19,6 @@ Note that you do not need to be a Tidelift subscriber to file a security contact
 
 To verify that any given Jackson artifact has been signed with a valid key, have a look at `KEYS` file of the main Jackson repo:
 
-https://github.com/FasterXML/jackson/blob/master/KEYS
+https://github.com/FasterXML/jackson/blob/main/KEYS
 
 which lists all known valid keys in use.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,6 @@
 
 `/docs/` used to contain Javadocs definitions, but since they can be found from:
 
-   http://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-annotations
+   https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-annotations
 
 are no longer stored in this repo.


### PR DESCRIPTION
This PR fixes broken and redirecting external URLs in Markdown documentation files.

README.md
Updated Apache 2.0 license URL to canonical HTTPS endpoint
Replaced broken Maven badge image/target links with working equivalents
Updated Javadoc link to canonical HTTPS endpoint
SECURITY.md
Updated CERT coordinated disclosure URL to canonical destination
Updated KEYS link from master to main
docs/README.md
Updated Javadoc URL to canonical HTTPS endpoint